### PR TITLE
fix berkshelf link for update api

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site :opscode
+source 'http://api.berkshelf.com'
 
 metadata


### PR DESCRIPTION
This link corrects the api link for berkshelf and prevents this warning

$ rspec
DEPRECATED: Your Berksfile contains a site location pointing to the Opscode Community Site (site :opscode). Site locations have been replaced by the source location. Change this to: 'source "http://api.berkshelf.com"' to remove this warning. For more information visit https://github.com/berkshelf/berkshelf/wiki/deprecated-locations
.....
