### PR TITLE
Allow installation into an existing directory

### DIFF
--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -35,7 +35,7 @@ execute 'install-nexpose' do
   user 'root'
   cwd Chef::Config['file_cache_path']
   command "#{installer.to_s} #{node['nexpose']['install_args'].join(' ')}"
-  not_if { ::Dir.exists?(node['nexpose']['install_path']['linux']) }
+  not_if { ::File.exists?(File.join(node['nexpose']['install_path']['linux'], 'shared')) }
 end
 
 # The init script for nexpose consoles and engines is named differently.

--- a/spec/unit/recipes/linux_spec.rb
+++ b/spec/unit/recipes/linux_spec.rb
@@ -49,7 +49,7 @@ describe 'broken tests' do
   # Disabled until I have more time to fix this issue.
   it 'does not install nexpose if it already is installed' do
     before { pending }
-    allow(::Dir).to receive(:exists?).with('/opt/rapid7/nexpose').and_return(true)
+    allow(::File).to receive(:exists?).with('/opt/rapid7/nexpose/shared').and_return(true)
     expect(chef_run).to run_execute('install-nexpose').with(not_if: true)
   end
 end


### PR DESCRIPTION
Sometimes a user may want to install Nexpose in a directory that already exists (for example a mount point created just for Nexpose).

This checks for the shared directory in the Nexpose directory to determine if Nexpose is already installed instead of checking for the root directory.
