### PR TITLE
Allow the use of console for component_type globally

### DIFF
--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -43,7 +43,7 @@ end
 # current version of Chef attempted call update-rc.d only with the provider
 # name.
 case node['nexpose']['component_type']
-when 'typical'
+when 'typical', 'console'
   nexpose_init = 'nexposeconsole.rc'
 when 'engine'
   nexpose_init = 'nexposeengine.rc'


### PR DESCRIPTION
Currently we are allowing a 'console' component_type on the default recipe only, not linux. This commit standardizes the use of 'console' for component_types globally.

See: ﻿﻿https://github.com/rapid7-cookbooks/nexpose/blob/master/recipes/default.rb#L22 for an example of how we are currently using console_type on the default recipe. 