### PR TITLE
Test install unattended comdir0

### DIFF
--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -42,7 +42,7 @@ company=<%= node['nexpose']['company_name'] %>
 ## Installation component type.
 sys.component.engine$Boolean=<%= @engine_bool %>
 sys.component.typical$Boolean=<%= @console_bool %>
-communicationDirectionChoice$Integer=0
+communicationDirectionChoice$Integer=1
 
 ###############################################################
 #IT IS STRONGLY RECOMMENDED NOT TO USE PLAIN TEXT PASSWORDS

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -42,6 +42,7 @@ company=<%= node['nexpose']['company_name'] %>
 ## Installation component type.
 sys.component.engine$Boolean=<%= @engine_bool %>
 sys.component.typical$Boolean=<%= @console_bool %>
+communicationDirectionChoice$Integer=0
 
 ###############################################################
 #IT IS STRONGLY RECOMMENDED NOT TO USE PLAIN TEXT PASSWORDS


### PR DESCRIPTION
This sets the default engine install communication direction choice to Console->Engine for unattended installs. If you want to do Engine-> Console communication engine installs you will need to supply the Console address and Shared secret for pairing. Or set the Skip Pairing flag.