### PR TITLE
Pin berkshelf and ridley gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,12 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
+# NOTE: This is being pinned to v4.0.1 to ensure no ridley dependency
+# collisions occur.
+# TODO: Remove this explicit dependency after the ridley pin is removed.
+gem 'berkshelf', '= 4.0.1'
+# NOTE: berkshelf usually transiently pulls in ridley.
+# TODO: Remove this explicit dependency which pins ridley to v4.3.2.
+gem 'ridley', '= 4.3.2'
 gem 'chefspec'
 gem 'knife-spec'
 gem 'test-kitchen'


### PR DESCRIPTION
recommended reviewers: @cdoughty-r7 @cmccrisken-r7 @abunn-r7

# Problem
The Nexpose DeployInstallers build began failing since `berks package`
depended on the `#chef_server_url` method which was removed from
[berkshelf/ridley@v4.4.0](https://github.com/berkshelf/ridley/compare/v4.4.0).

# Solution
* Pinning berkshelf to v4.0.1.
* Pinning ridley to v4.3.2.

# References 
* https://github.com/berkshelf/ridley/compare/v4.3.2...v4.4.0
* https://github.com/berkshelf/berkshelf/issues/1494, https://github.com/berkshelf/berkshelf/issues/1495, and https://github.com/berkshelf/ridley/issues/330
* `Ridley::Chef::Config#chef_server_url` was [removed here](https://github.com/berkshelf/ridley/compare/v4.3.2...v4.4.0#diff-ae02933bcda1a5eb6175fb378e606f16L47).