### PR TITLE
Manually specify the init command

### DIFF
--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -64,6 +64,7 @@ end
 
 service nexpose_init do
   supports :status => true, :restart => true
+  init_command "/etc/init.d/#{nexpose_init}"
   action node['nexpose']['service_action']
 end
 


### PR DESCRIPTION
Fixes an issue where sometimes chef will look for nexpose_init in /etc/init but not /etc/init.d:
```
    virtualbox-iso: ================================================================================
    virtualbox-iso: Error executing action `enable` on resource 'service[nexposeconsole.rc]'
    virtualbox-iso: ================================================================================
    virtualbox-iso:
    virtualbox-iso: ArgumentError
    virtualbox-iso: -------------
    virtualbox-iso: File '/etc/init/nexposeconsole.rc.conf' does not exist
    virtualbox-iso:
    virtualbox-iso: Resource Declaration:
    virtualbox-iso: ---------------------
    virtualbox-iso: # In /tmp/packer-chef-solo/cookbooks-0/nexpose/recipes/linux.rb
    virtualbox-iso:
    virtualbox-iso: 57: service nexpose_init do
    virtualbox-iso: 58:   supports :status => false, :restart => true
    virtualbox-iso: 59:   action node['nexpose']['service_action']
    virtualbox-iso: 60: end
    virtualbox-iso: 61:
```