### PR TITLE
Add support for custom environment properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ Attributes
     <td>Array of arguments passed to the installer.<tt>
     <td><tt>['-q', '-dir', node['nexpose']['install_path'][node[os]], '-Dinstall4j.suppressUnattendedReboot=' + node['nexpose']['suppress_reboot'].to_s, '-varfile', File.join(Chef::Config['file_cache_path'], 'response.varfile')]</td></tt>
   </tr>
+  <tr>
+    <td><tt>['nexpose']['custom_properties']</tt></td>
+    <td>Hash</td>
+    <td>Hash of key value pairs to be written to <install_path>/{nsc,nse}/CustomEnvironment.properties<tt>
+    <td><tt>{}</tt></td>
+  </tr>
 </table>
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -63,3 +63,4 @@ default['nexpose']['install_args'] = ['-q',
                                       '-dir', node['nexpose']['install_path'][node['os']].to_s,
                                       '-Dinstall4j.suppressUnattendedReboot=' + node['nexpose']['suppress_reboot'].to_s,
                                       '-varfile', ::File.join(Chef::Config['file_cache_path'], 'response.varfile')]
+default['nexpose']['custom_properties'] = {}

--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -63,6 +63,20 @@ template ::File.join('/etc/init.d', nexpose_init) do
   })
 end
 
+# Path to environment file is different for engines and consoles.
+case node['nexpose']['component_type']
+when 'typical', 'console'
+  environment_file = ::File.join(node['nexpose']['install_path'][node['os']], 'nsc', 'CustomEnvironment.properties')
+when 'engine'
+  environment_file = ::File.join(node['nexpose']['install_path'][node['os']], 'nse', 'CustomEnvironment.properties')
+else
+  log "Invalid nexpose compontent_type specified: #{node['nexpose']['component_type']}. Valid component_types are typical and engine"
+end
+
+template environment_file do
+  not_if { node['nexpose']['custom_properties'].empty? }
+end
+
 service nexpose_init do
   supports :status => true, :restart => true
   init_command "/etc/init.d/#{nexpose_init}"

--- a/templates/default/CustomEnvironment.properties.erb
+++ b/templates/default/CustomEnvironment.properties.erb
@@ -1,0 +1,3 @@
+<% node['nexpose']['custom_properties'].each do |k,v| %>
+<%= k %>=<%= v %>
+<% end %>


### PR DESCRIPTION
Adds support for setting values in `CustomEnvironment.properties` located in `<install_path>/{nsc,nse}`. These properties are read in when nexpose initializes. 