### PR TITLE
Add option to reset password on login

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Attributes
     <td><tt>nxadmin</tt></td>
   </tr>
   <tr>
+    <td><tt>['nexpose']['require_password_change']</tt></td>
+    <td>Boolean</td>
+    <td>Require password reset upon login?</td>
+    <td><tt>false</tt></td>
+  </tr>
+  <tr>
     <td><tt>['nexpose']['install_args']</tt></td>
     <td>Array</td>
     <td>Array of arguments passed to the installer.<tt>

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,6 +50,7 @@ default['nexpose']['component_type'] = 'typical'
 # Credentials
 default['nexpose']['username'] = 'nxadmin'
 default['nexpose']['password'] = 'nxadmin'
+default['nexpose']['require_password_change'] = false
 # Shortcuts and Start Menu configs
 default['nexpose']['create_desktop_icon'] = true
 default['nexpose']['shortcuts_for_all_users'] = true

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -55,6 +55,7 @@ communicationDirectionChoice$Integer=1
 #username=jsmith
 #password1=example
 #password2=example
+#requirePasswordChange$Boolean=false
 #
 #NOTE: A response file created by running the installer will contain the
 # options "password1.encoded" and "password2.encoded" and a encoded
@@ -67,6 +68,7 @@ communicationDirectionChoice$Integer=1
 username=<%= node['nexpose']['username'] %>
 password1=<%= node['nexpose']['password'] %>
 password2=<%= node['nexpose']['password'] %>
+requirePasswordChange$Boolean=<%= !!node['nexpose']['require_password_change'] %>
  
 #INSTALL PATH SEPERATOR MUST BE ESCAPED
 #sys.installationDir=C:\\Program Files\\Rapid7\\custom


### PR DESCRIPTION
This adds a new attribute: `require_password_change`.  If set to `true` the user will be required to reset their password on first login.

To maintain backwards compatibility, the default value is `false`.