### PR TITLE
Fix hashie dependency, recent versions break berkshelf

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gem 'berkshelf', '~> 4.0.1'
 # NOTE: berkshelf usually transiently pulls in ridley.
 # TODO: Remove this explicit dependency which pins ridley to v4.4.2.
 gem 'ridley', '~> 4.4.2'
+# TODO: berkshelf 4.x is broken with hashie 3.5.x
+gem 'hashie', '~> 3.4.3'
 gem 'chefspec'
 gem 'knife-spec'
 gem 'test-kitchen', '~> 1.4.2'


### PR DESCRIPTION
Pins hashie to 3.4.3, last known version to work with berkshelf 4.x