### PR TITLE
Creating option for Communication direction

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,7 +47,7 @@ default['nexpose']['last_name'] = 'User'
 default['nexpose']['company_name'] = 'Rapid7'
 # Install type (typical || engine)
 default['nexpose']['component_type'] = 'typical'
-# Communication direction (1 => Engine->Console || 2=> Console->Engine)
+# Communication direction (1 => Engine->Console || 2 => Console->Engine)
 default['nexpose']['communication_direction'] = 1
 # Credentials
 default['nexpose']['username'] = 'nxadmin'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -47,6 +47,8 @@ default['nexpose']['last_name'] = 'User'
 default['nexpose']['company_name'] = 'Rapid7'
 # Install type (typical || engine)
 default['nexpose']['component_type'] = 'typical'
+# Communication direction (1 => Engine->Console || 2=> Console->Engine)
+default['nexpose']['communication_direction'] = 1
 # Credentials
 default['nexpose']['username'] = 'nxadmin'
 default['nexpose']['password'] = 'nxadmin'

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -42,7 +42,7 @@ company=<%= node['nexpose']['company_name'] %>
 ## Installation component type.
 sys.component.engine$Boolean=<%= @engine_bool %>
 sys.component.typical$Boolean=<%= @console_bool %>
-communicationDirectionChoice$Integer=1
+communicationDirectionChoice$Integer= <%= node['nexpose']['communication_direction'] %>
 
 ###############################################################
 #IT IS STRONGLY RECOMMENDED NOT TO USE PLAIN TEXT PASSWORDS

--- a/templates/default/response.varfile.erb
+++ b/templates/default/response.varfile.erb
@@ -42,7 +42,7 @@ company=<%= node['nexpose']['company_name'] %>
 ## Installation component type.
 sys.component.engine$Boolean=<%= @engine_bool %>
 sys.component.typical$Boolean=<%= @console_bool %>
-communicationDirectionChoice$Integer= <%= node['nexpose']['communication_direction'] %>
+communicationDirectionChoice$Integer=<%= node['nexpose']['communication_direction'] %>
 
 ###############################################################
 #IT IS STRONGLY RECOMMENDED NOT TO USE PLAIN TEXT PASSWORDS


### PR DESCRIPTION
Hoping to add to the next release the ability to choose the communication direction when installing a standalone scan engine. Enables users that choose this option to connect to new engines quicker when environment is set up where the console talk to engines instead of the other way around