### PR TITLE
Use ignore_failure for screen package

### DIFF
--- a/recipes/linux.rb
+++ b/recipes/linux.rb
@@ -19,7 +19,9 @@
 #
 
 # Install Nexpose Pre-Reqs
-package 'screen' unless node['platform_family'] == 'rhel' # rhel requires CD/ISO to be mounted to install screen
+package 'screen' do
+  ignore_failure true
+end
 
 installer = ::File.join(Chef::Config['file_cache_path'], node['nexpose']['installer']['bin'])
 


### PR DESCRIPTION
Instead of just skipping the screen package installation on rhel, it is better to ignore_failure: ensuring that paying rhel customers get updates for the screen package.