### PR TITLE
Fetch nexpose installer artifact over HTTPS instead of HTTP

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,7 +33,7 @@ default['nexpose']['installer']['windows']['bin'] = 'Rapid7Setup-Windows64.exe'
 default['nexpose']['installer']['windows']['checksum'] = nil
 # Set the bin URL based on the detected OS value. Supported values are Linux and Windows.
 default['nexpose']['installer']['bin'] = node['nexpose']['installer'][node['os']]['bin']
-default['nexpose']['installer']['uri'] = "http://download2.rapid7.com/download/InsightVM/#{node['nexpose']['installer']['bin']}"
+default['nexpose']['installer']['uri'] = "https://download2.rapid7.com/download/InsightVM/#{node['nexpose']['installer']['bin']}"
 
 
 default['nexpose']['install_path']['linux'] = ::File.join('/', 'opt', 'rapid7', node['rapid7']['product'].downcase.rstrip)


### PR DESCRIPTION
After fetching this URI the recipe runs it as root.  Short of
verifying the integrity of the installer in some way, the installer
should be downloaded over HTTPS at the least.

Note that there's a `checksum` directive in the `remote_file`, but
that doesn't do what you might think it does: instead of verifying
that the downloaded artifact has the expected checksum, it just uses
the checksum as a hint to tell whether to re-download the file.